### PR TITLE
Add module docs and update philosophy in README

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,0 +1,234 @@
+# Feather vs Shells — Practical Side‑by‑Side Examples
+
+This page shows how common automation tasks look in **Bash**, **Windows CMD**, **PowerShell**, and **Feather**.  
+Feather favors **clarity and safety**: one action per line, explicit modules, and an explicit result.
+
+> Tip: In Feather examples below, endings like `success.` or `failure.` are intentional. A script that reaches the end without a result is considered failed by design.
+
+---
+
+## Task 1 — Greet user from an environment variable with a fallback
+
+### Bash
+
+```bash
+name="${USER:-world}"
+echo "Hello, $name"
+```
+
+### CMD
+
+```bat
+set "name=%USERNAME%"
+if "%name%"=="" set "name=world"
+echo Hello, %name%
+```
+
+### PowerShell
+
+```powershell
+$name = $env:USERNAME
+if ([string]::IsNullOrEmpty($name)) { $name = 'world' }
+Write-Host "Hello, $name"
+```
+
+### Feather
+
+```sky
+system get 'USERNAME' into @name.
+
+if(bool eval (string require @name))
+  failure 'name is empty'
+end
+
+say 'Hello @{name}'.
+success.
+```
+
+---
+
+## Task 2 — Read a JSON file and print a field (`config.json` → `user.name`)
+
+### Bash (with jq)
+
+```bash
+name=$(jq -r '.user.name' config.json)
+echo "User: $name"
+```
+
+### CMD (calls PowerShell for JSON)
+
+```bat
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "(Get-Content config.json | ConvertFrom-Json).user.name"`) do set "name=%%i"
+echo User: %name%
+```
+
+### PowerShell
+
+```powershell
+$obj = Get-Content config.json | ConvertFrom-Json
+Write-Host "User: $($obj.user.name)"
+```
+
+### Feather
+
+```sky
+cabinet read file 'config.json' as json into ::cfg.
+say 'User: @{::cfg:content:user:name}'.
+success.
+```
+
+---
+
+## Task 3 — Backup a folder with a datestamped name
+
+> Copy `./project` to `./backups/project_YYYY-MM-DD`
+
+### Bash
+
+```bash
+date=$(date +%F)
+cp -a ./project "./backups/project_$date"
+```
+
+### CMD
+
+```bat
+for /f "tokens=1-3 delims=/ " %%a in ("%date%") do set dt=%%c-%%a-%%b
+xcopy /e /i /y project "backups\\project_%dt%"
+```
+
+### PowerShell
+
+```powershell
+$dt = Get-Date -Format "yyyy-MM-dd"
+Copy-Item -Recurse -Force ./project "backups/project_$dt"
+```
+
+### Feather
+
+```sky
+time now format 'YYYY-MM-DD' into @dt.
+cabinet copy folder './project' to 'backups/project_@{dt}'.
+success 'backup complete'.
+```
+
+---
+
+## Task 4 — Find files containing text (recursive) and print matches
+
+### Bash (ripgrep/grep)
+
+```bash
+grep -R --line-number --ignore-case "TODO" ./src
+```
+
+### CMD
+
+```bat
+findstr /S /N /I /C:"TODO" src\*.*
+```
+
+### PowerShell
+
+```powershell
+Select-String -Path .\src\* -Pattern "TODO" -SimpleMatch -CaseInsensitive
+```
+
+### Feather
+
+```sky
+cabinet list in './src' with recursion as tree into ::files
+text lower 'TODO' into @needle.
+
+iterate ::files as ::file
+  cabinet read file ::file:path into @content.
+  bool eval text contains @content @needle into @has.
+  if @has
+    say '@{::file:path}'
+  end
+end
+
+success.
+```
+
+---
+
+## Task 5 — Dangerous delete, but **safe by default**
+
+> Delete a temp folder. In Feather we mark it `safe` so failures won’t halt the script, and we can add `chrono` to time it.
+
+### Bash
+
+```bash
+rm -rf ./temp || true
+```
+
+### CMD
+
+```bat
+rmdir /s /q temp
+```
+
+### PowerShell
+
+```powershell
+Remove-Item -Recurse -Force ./temp -ErrorAction SilentlyContinue
+```
+
+### Feather
+
+```sky
+safe cabinet delete folder './temp' with force chrono.
+success.
+```
+
+---
+
+## Task 6 — Simple arithmetic with a check
+
+### Bash
+
+```bash
+a=5; b=7
+sum=$((a + b))
+if [ "$sum" -gt 10 ]; then echo "ok"; fi
+```
+
+### CMD
+
+```bat
+set /a sum=5+7
+if %sum% gtr 10 echo ok
+```
+
+### PowerShell
+
+```powershell
+$sum = 5 + 7
+if ($sum -gt 10) { Write-Host "ok" }
+```
+
+### Feather
+
+```sky
+math add '5' '7' into @sum.
+bool eval @sum > '10' into @ok.
+if @ok
+  say 'ok'.
+end
+success.
+```
+
+---
+
+## Notes on Philosophy
+
+- Feather prefers **clarity over cleverness**: explicit modules (`cabinet`, `text`, `math`, `time`) and one action per line.
+- Security is **opt‑in explicit**: use `safe`, `sensitive`, and `with risk` where appropriate.
+- Scripts **must** end with a `success`/`failure`, making outcomes unambiguous.
+- Use **`eval`** for expression grammar _inside a module_ (`math eval`, `bool eval`), and **`@{}` only for string interpolation**.
+
+---
+
+## _Have a great mini‑example you want to add? Drop it here and we’ll keep this page tight and practical._

--- a/README.md
+++ b/README.md
@@ -5,21 +5,23 @@
 Feather is a lightweight scripting and automation language with a built-in interactive mode called Sky.
 It is designed to be embedded in applications or used as a standalone, elegant, and fast scripting interface. It is written in Rust.
 
+# Why Feather?
+
+Feather's strength lies in its core architectural principles and design choices that emphasize clarity, safety, and composability. The language enforces strong type safety and includes secure-by-default features that protect users from common scripting pitfalls. Its readability-first rules make scripts accessible and maintainable, even for those unfamiliar with Feather.
+
+While this design approach makes Feather scripts harder to write quickly, it makes them much easier to read, understand, and maintain over time. This balance ensures that Feather is a reliable tool for automation and scripting tasks, fostering confidence and reducing errors.
+
+Key principles behind Feather's design include:
+
+- Clear and explicit logic that prioritizes understanding over brevity
+- Strong type safety to catch errors early
+- Secure-by-default operations to enhance script safety
+- Composability that encourages building complex workflows from simple, understandable parts
+- Readability-first rules that make scripts approachable for all users
+
 # Goals
 
 To create an elegant, fast and reliable library and REPL to make scripting easy, intuitive and simple. Even if feather might not be able to do anything, the goal is to make everything in the best possible way
-
-# Syntax Philosophy
-
-Feather is built on a simple idea:
-
-> Scripting shouldn’t feel like deciphering a puzzle. It should feels as if you are explaining steps to a machine.
-
-We prioritize:
-
-- Clarity over cleverness
-- Consistency over conciseness
-- Composability over complexity
 
 # Performance Philosophy
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,6 @@ Welcome to the Feather documentation. Here you'll find guides and references for
 - **WIP** [Functions](./syntax/functions.md) — Defining and using functions, parameters, and return values.
 - **WIP** [Lenses](./syntax/lenses.md) — Ephemeral views and type conversions.
 - **WIP** [Modifiers](./syntax/modifiers.md) — Enhancing commands with options (with, without, filter).
-- **WIP** [Operators](./syntax/operators.md) — Supported operators and their usage.
 - **WIP** [Signatures](./syntax/signatures.md) — Platform targeting, telemetry, and execution control.
 
 # Modules

--- a/docs/lint/codes.md
+++ b/docs/lint/codes.md
@@ -1,0 +1,9 @@
+FEATHER ALERTS/ERROR
+
+FEA
+
+    •	0xx = Syntax / parsing errors
+    •	1xx = Module misuse (wrong arguments, wrong order)
+    •	2xx = Type/domain issues (mixed types, missing lens)
+    •	3xx = Flow/style issues (too many inline evals, multi-domain in one command)
+    •	9xx = Internal/engine errors

--- a/docs/modules/binary.md
+++ b/docs/modules/binary.md
@@ -1,0 +1,5 @@
+bool
+• bool eval <expr> into @ok (can reference math/text comparisons)
+• bool all <pred1> <pred2> … into @ok (multi-line friendly)
+• bool any <pred1> <pred2> … into @ok
+• bool not @ok into @neg

--- a/docs/modules/container.md
+++ b/docs/modules/container.md
@@ -1,0 +1,9 @@
+list / map (containers)
+• list add ::xs 'item'.
+• list remove ::xs 'item'.
+• list length ::xs into @n
+• list join ::xs with ', ' into @s
+• map set ::m 'key' 'value'.
+• map get ::m 'key' into @v
+• map has ::m 'key' into @ok
+• map merge ::a ::b into ::out

--- a/docs/modules/math.md
+++ b/docs/modules/math.md
@@ -1,0 +1,34 @@
+# Math
+
+## Description
+The module Math provides all the necessary logic to operate on record in a mathematical way. Since records are all string, it lenses as integer internally, providing the right logic and validation logic internally.
+
+- `eval`
+  - `with`:
+    - `rounding`:
+- `add`:
+- `sub`:
+- `mul`:
+- `mod`:
+- `abs`:
+- `round`:
+- `floor`:
+- `ceil`:
+- `clamp`:
+- `pow`:
+- `random`:
+
+
+
+
+
+
+math eval <expr> — arithmetic/compare, precedence, parentheses
+	•	math add|sub|mul|div @a @b into @c
+	•	math mod @a @b into @r
+	•	math abs @n into @out
+	•	math round|floor|ceil @n into @out
+	•	math min|max @a @b into @out
+	•	math clamp @n min '0' max '100' into @out
+	•	math pow @n '2' into @sq
+	•	(optional) math random min '0' max '1' into @r

--- a/docs/modules/record.md
+++ b/docs/modules/record.md
@@ -1,0 +1,13 @@
+record delete @rec. # remove record entirely (unset/clear)
+record exists @rec into @ok. # check if record is bound and non-empty
+record empty @rec into @ok. # check if value == ''
+record length @rec into @len. # number of characters
+record matches @rec 'regex' into @ok.
+record is-numeric @rec into @ok.
+record is-integer @rec into @ok.
+record is-decimal @rec into @ok.
+record is-date @rec 'YYYY-MM-DD' into @ok.
+record lens @rec as integer into @out. # throws if invalid
+record try-lens @rec as integer into @out ok @ok. # sets @ok true/false
+record lens @rec as decimal into @out.
+record lens @rec as json into ::container.

--- a/docs/modules/text.md
+++ b/docs/modules/text.md
@@ -1,0 +1,20 @@
+# Text
+
+## Description
+
+    •	text concat @a @b into @out
+    •	text join ::items with ', ' into @csv
+    •	text split @s by ',' into ::parts
+    •	text replace @s 'from' 'to' into @t
+    •	text contains @s 'needle' into @has
+    •	text startswith|endswith @s 'pre/suf' into @ok
+    •	text trim|lower|upper @s into @out
+    •	text length @s into @len
+    •	text slice @s from '2' to '5' into @sub
+    •	text format 'Hello {name}' with name @n into @msg
+    •	(optional) text match @s 'regex' into ::matches
+
+Optional / separate:
+• assert @ok 'message'. → fails the script if @ok is false (side-effect; not a bool op)
+
+

--- a/docs/modules/time.md
+++ b/docs/modules/time.md
@@ -1,0 +1,7 @@
+time
+• time now into ::t
+• time parse '2025-08-08T12:00:00Z' into ::t
+• time add ::t days '7' into ::t2
+• time diff ::a ::b in 'days' into @days
+• time format ::t 'YYYY-MM-DD' into @s
+• time compare ::a after|before|equal ::b into @ok

--- a/docs/syntax/modifiers.md
+++ b/docs/syntax/modifiers.md
@@ -20,7 +20,7 @@ cabinet file list
   with depth '3'
   with hidden
   without extension
-  filter '[A-z]'
+  filter '[A-z]'.
 ```
 
 This replaces obscure flags with self-explanatory modifiers. You can also chain them inline:

--- a/docs/syntax/signatures.md
+++ b/docs/syntax/signatures.md
@@ -1,45 +1,65 @@
 # Signatures
 
-- Control data flow or execution logic across instructions.
-- Typically at the end or in fixed positions.
-- Tend to be verbs or control structures.
+Signatures are the last instructions of a command. It provides meta logic related to the overall command.
 
-silent, memo, profile
+The following signatures are:
 
 1. `on`
-2. `memo`
+2. `trace`
 3. `chronos`
-
-   • Logging tags (telemetry):
+4. `silent`
+5. `timeout`
 
 ## `on`
 
 `on` is a signature to indicate that the execution will be done only if the machine is from the specified OS family.
 
-Supported instructions: `mac`, `windows`, `linux`, `unix`
+Supported instructions: `mac`, `windows`, `linux`.
 
-### Example
+### Examples
 
-#### .sky Script
+**Script**
 
 ```sky
-say 'I am on linux' on linux.
-say 'I am on mac' on mac.
-say 'I am on windows' on windows.
-say 'I am on BSD' on unix.
+say 'I am on linux.' on linux.
+say 'I am on mac.' on mac.
+say 'I am on windows.' on windows.
 success 'This has run on a mac desktop>'.
 ```
 
+**Output**
+
 ```
-~ [INFO] I am on mac
+~ [INFO] I am on mac.
 ~ [SUCC] This has run on mac desktop.
 ```
 
-## `memento`
+## `trace`
+
+The instruction `trace` forces the printing of the actual command. it's use mostly to investigate a script to make sure everything is going well or just track the command process.
+
+**Script**
+
+```sky
+say 'I am on linux.' trace on linux.
+say 'I am on mac.' trace on mac.
+say 'I am on windows.' trace on windows.
+success 'This has run on a mac desktop>'.
+```
+
+**Output**
+
+```
+~ [TRCE] Say 'I am on linux' trace on linux.
+~ [TRCE] Say 'I am on mac' trace on mac.
+~ [INFO] I am on mac
+~ [TRCE] Say 'I am on windows' trace on windows.
+~ [SUCC] This has run on mac desktop.
+```
 
 ## `chrono`
 
-## timeout
+## `timeout`
 
 Track the time it took to execute the command.
 


### PR DESCRIPTION
Added documentation for modules: binary, container, math, record, text, and time. Renamed operators doc to bool. Updated README with expanded philosophy and rationale for Feather's design. Added EXAMPLE.md with practical scripting comparisons. Updated index and modifiers docs to reflect new structure and clarified signatures documentation.